### PR TITLE
Add AO assignment hint to `show AOs` command

### DIFF
--- a/src/robot-scripts/active-owner.coffee
+++ b/src/robot-scripts/active-owner.coffee
@@ -41,10 +41,9 @@ module.exports = (robot) ->
         "#{aoName} has been active owner on #{team.name} " +
         "for #{moment(team.aoUserAssignedDt).fromNow(true)}"
       else
-        "* #{team.name} has no active owner! " +
-        "Use: 'Assign <user> as AO for <team>'."
+        "* #{team.name} has no active owner! "
     aoDescriptions = (aoDescription(teams[prop]) for prop of teams)
-    msg.send "AOs:\n" + aoDescriptions.join("\n")
+    msg.send "AOs:\n" + aoDescriptions.join("\n") + "\n\nUse: 'Assign <user> as AO for <team>' to assign an AO."
 
   robot.respond /(list|show) review list/i, (msg) ->
     reviews = robot.brain.data.reviews


### PR DESCRIPTION
This PR aims to improve displayed message to suggest plausible next commands that the user would like to do, pretty much like `git` does when you do a `git status` for example.
## Current output

```
Frederic Choquet has been active owner on core for 16 days 
Joseph Palmour has been active owner on Platform Integrity for 15 days
Rosalie Deletre has been active owner on Rapid Response for 15 days 
Ray Ashman has been active owner on Feature for 8 days
```
## With this PR

```
Frederic Choquet has been active owner on core for 16 days 
Joseph Palmour has been active owner on Platform Integrity for 15 days
Rosalie Deletre has been active owner on Rapid Response for 15 days 
Ray Ashman has been active owner on Feature for 8 days

Use: 'Assign <user> as AO for <team>' to assign an AO.
```
