### PR TITLE
Adding in force push notification for SeaBone

### DIFF
--- a/src/Push.coffee
+++ b/src/Push.coffee
@@ -1,0 +1,11 @@
+class Push
+  constructor: (pushEvent) ->
+    @force = pushEvent.forced
+    @shaBefore = pushEvent.before
+    @repo = pushEvent.repository.full_name
+    pushEvent.ref = pushEvent.ref.split('/');
+    @branch = pushEvent.ref[2]
+    @user = pushEvent.pusher.login
+    @time = new Date()
+
+module.exports = Push 

--- a/src/robot-scripts/force-push.coffee
+++ b/src/robot-scripts/force-push.coffee
@@ -1,0 +1,11 @@
+# Description
+#   Message AOs about master or a release branch being force pushed too.
+AOHelper = require '../ActiveOwnerHelper'
+
+module.exports = (robot) ->
+
+  helper = new AOHelper robot
+
+  robot.on 'force-push', (push) ->
+    message = "#{push.branch} has been forced push by #{push.user} onto #{push.repo}. Last commit hash before the push was #{push.shaBefore}." 
+    helper.messageAOs message

--- a/src/robot-scripts/webhook-listener.coffee
+++ b/src/robot-scripts/webhook-listener.coffee
@@ -4,31 +4,41 @@
 
 AOHelper = require '../ActiveOwnerHelper'
 Review = require '../Review'
+Push = require '../Push'
 
 module.exports = (robot) ->
 
   helper = new AOHelper robot
+  branchPattern = ///^refs/heads/release-[0-9.]*$///
 
   robot.router.post '/hubot/gh', (req, res) ->
     robot.logger.debug 'GitHub webhook request received.'
+    test = req.body.ref
     res.send 200
-    return if ! req.body.pull_request
-    robot.logger.debug "Processing pull_request event. " +
-      "action: #{req.body.action}"
-    review = new Review(req.body)
-    if req.body.action == 'labeled' &&
-    req.body.label.name == process.env.HUBOT_REVIEW_NEEDED_LABEL
+    
+    review = new Review(req.body) if req.body.pull_request
+    push = new Push(req.body) if req.body.forced
+
+    if req.body.action == 'labeled' and req.body.label.name == process.env.HUBOT_REVIEW_NEEDED_LABEL and req.body.pull_request
       robot.logger.debug "Emitted review-needed event for " +
       "#{req.body.pull_request.html_url}"
       robot.emit 'review-needed', review
-    if reviewNoLongerNeeded req.body
+
+    if req.body.pull_request and reviewNoLongerNeeded req.body
       robot.logger.debug "Emitted review-closed event for " +
       "#{req.body.pull_request.html_url}"
       robot.emit 'review-complete', review
 
+    #push needs to be the last choice
+    if req.body.forced and (test == 'refs/heads/master' or test.match branchPattern)
+      robot.logger.debug "Emitted force-push notice" +
+      "#{req.body.ref}"
+      robot.emit 'force-push', push
+    
   reviewNoLongerNeeded = (body) ->
     labelRemoved = body.action == 'unlabeled' &&
       body.label.name == process.env.HUBOT_REVIEW_NEEDED_LABEL
     prClosed = body.action == 'closed' &&
       helper.getReview "#{body.repository.full_name}/#{body.number}"
     labelRemoved || prClosed
+


### PR DESCRIPTION
This is adding in Force Push notification for AOs. Will need alter web hook to also add in pull and push requests for this to work, but should be done after (staggered) deployment so we can verify. Will later need to add backup links so we can restore when someone force pushes. 
